### PR TITLE
Add background information to scene description

### DIFF
--- a/SCHEMA.md
+++ b/SCHEMA.md
@@ -87,7 +87,7 @@ Each document in the `scenes` collection may have the following fields:
   encouraged to click
 - `content`: information about the actual contents of the scene
   - `image_layers`: optional array of ImageLayer records (see below).
-- `background_id`: (optional ObjectID) The ObjectID of the scene's background image
+  - `background_id`: (optional ObjectID) The ObjectID of the scene's background image
 - `previews`: information about different preview types
   - `video`: (optional string) The basename of the video preview in its blob container, if one exists
   - `thumbnail`: (optional string) The basename of the preview thumbnail image in the blob container, if one exists


### PR DESCRIPTION
This PR adds an optional `background_id` to the schema for the scene inside the Mongo database. If present, this field should be an `ObjectId` containing the ID of the imageset being used for the background. Adding the background to the constructed JSON follows a similar process as with image layers, with the simplification that we don't need an opacity here.

@pkgw One thing I've been debating is whether we should generate a "name" for this imageset in the frontend or backend. I'm currently thinking we can generate it in the frontend where we construct the actual `Imageset` object, and so this PR doesn't include anything on that front.