### PR TITLE
Allow em tag in sanitized HTML

### DIFF
--- a/util.ts
+++ b/util.ts
@@ -80,7 +80,7 @@ export const CleanHtml = new t.Type<string, string, unknown>(
   // Sanitize the HTML string as part of the parsing process
   (input: unknown, context: t.Context) => pipe(
     t.string.validate(input, context),
-    e.chain((str) => t.success(DOMPurify.sanitize(str, { ALLOWED_TAGS: ['b', 'strong', 'i', 'a', 'br'] })))
+    e.chain((str) => t.success(DOMPurify.sanitize(str, { ALLOWED_TAGS: ['b', 'strong', 'i', 'em', 'a', 'br'] })))
   ),
 
   // We don't need any custom encoding - just use the string encoder


### PR DESCRIPTION
In the course of updating the API client to include the image permissions, I realized that if we're going to allow `i` tags in the sanitized HTML, we should allow `em` tags too. This PR does that.