### PR TITLE
Updates to tessellation infrastructure

### DIFF
--- a/superuser.ts
+++ b/superuser.ts
@@ -66,7 +66,7 @@ export function initializeSuperuserEndpoints(state: State) {
         await state.scenes.createIndex({ "creation_date": 1 });
         await state.scenes.createIndex({ "home_timeline_sort_key": 1 });
         await state.events.createIndex({ "date": 1 });
-        await state.tessellations.createIndex({ "name": 1 });
+        await state.tessellations.createIndex({ "name": 1 }, { unique: true });
 
         res.json({ error: false });
       } catch (err) {

--- a/tessellation.ts
+++ b/tessellation.ts
@@ -1,4 +1,4 @@
-import { Filter, ObjectId, WithId } from "mongodb";
+import { ObjectId, WithId } from "mongodb";
 import { MongoScene } from "./scenes.js";
 import { distance, D2R, R2D } from "@wwtelescope/astro";
 import { GeoVoronoi, geoVoronoi, PointSpherical } from "d3-geo-voronoi";
@@ -107,21 +107,9 @@ export function initializeTessellationEndpoints(state: State) {
     * the tessellation ID
     */
   state.app.get(
-    "/tessellations/cell",
+    "/tessellations/:key/cell",
     async (req: JwtRequest, res: Response) => {
-      if (!(req.query.id || req.query.name)) {
-        res.statusCode = 400;
-        res.json({
-          error: true,
-          message: "You must include either an id or name to identify a tessellation"
-        });
-        return
-      }
-      
-      const filter: Filter<MongoTessellation> = req.query.id
-        ? { "_id": new ObjectId(req.query.id as string) }
-        : { "name": req.query.name };
-      const tessellation = await state.tessellations.findOne(filter);
+      const tessellation = await state.tessellations.findOne({ name: req.params.key });
 
       if (tessellation === null) {
         res.statusCode = 404;


### PR DESCRIPTION
While exploring adding some tessellation-related functionality to the frontend, I noticed some bugs and areas for improvement in the tessellation setup. The bug fixes are straightforward - the endpoint was accidentally parsing RA and Dec as integers rather than floats, and I made a mistake in how I was transforming RA-space between our scenes and the tessellation code (necessary because `d3-geo-voronoi` uses -180 to 180 for longitude).

As for the more design choice-stuff, this PR modifies the tessellation endpoint to allow specifying either the tessellation ID or name as query parameters when asking for a location's cell. The reason for this is that, while the concept of, for example, a "global tessellation" is likely something that will persist, I don't know that it's certain that it will always be the same exact document in the database collection. I feel like it's more natural to have a higher-level way to reference what we want in the API call, rather than need to hard-code in certain object IDs. If we do stick with this, it would obviously behoove us to have the name be an indexed (and unique) field.

This PR also contains a basic implementation of a global tessellation. The implementation is pretty straightforward, and there are certainly a lot of ways one could imagine creating something like this. The idea here is that we run through our list of scenes (in decreasing home timeline order) and only keep ones that are some threshold distance away from something that we've already seen. This prevents degenerate cells from repeated points (which cause problems in the index-based system that `d3-geo-voronoi` uses), and also essentially sets the resolution of the tessellation. If one is worried about losing some popular scenes due to this method, I can also imagine having a scheme where the acceptance condition is a function of both distance and the popularity index.