### PR TITLE
Only include items with non-negative home_timeline_sort_key in the home timeline

### DIFF
--- a/SCHEMA.md
+++ b/SCHEMA.md
@@ -109,8 +109,9 @@ Each document in the `scenes` collection may have the following fields:
     container, if one exists
   - `thumbnail`: (optional string) The basename of the preview thumbnail image
     in the blob container, if one exists
-- `home_timeline_sort_key` (integer): if present, the scene is included in the
-  global home timeline, with its position set by the ordering of these values.
+- `home_timeline_sort_key` (integer): if present and non-negative, the scene is
+  included in the global home timeline, with its position set by the ordering of
+  these values.
 
 An ImageLayer record may have the following fields:
 

--- a/scenes.ts
+++ b/scenes.ts
@@ -765,7 +765,7 @@ export function initializeSceneEndpoints(state: State) {
           res.json({ error: true, message: `invalid page number` });
         }
 
-        const docs = await state.scenes.find()
+        const docs = await state.scenes.find({ home_timeline_sort_key: { $gte: 0 } })
           .sort({ home_timeline_sort_key: 1 })
           .skip(page_num * page_size)
           .limit(page_size)

--- a/tessellation.ts
+++ b/tessellation.ts
@@ -83,8 +83,9 @@ export function findCell(tessellation: MongoTessellation, raRad: number, decRad:
   * scale quadratically with the number of scenes.
   */
 export async function createGlobalTessellation(state: State, minDistanceRad = 0.01): Promise<MongoTessellation> {
-  const scenes = state.scenes.find({}).sort({ home_timeline_sort_key: 1 });
+  const scenes = state.scenes.find({ home_timeline_sort_key: { $gte: 0 } }).sort({ home_timeline_sort_key: 1 });
   const tessellationScenes: WithId<MongoScene>[] = [];
+
   for await (const scene of scenes) {
     const place = scene.place;
     const accept = tessellationScenes.every(s => {


### PR DESCRIPTION
Without applying this filter, it turned out that items without any home_timeline_sort_key specified were bubbling up to the top.