### PR TITLE
Allow marking scenes as published or not

### DIFF
--- a/SCHEMA.md
+++ b/SCHEMA.md
@@ -109,6 +109,8 @@ Each document in the `scenes` collection may have the following fields:
     container, if one exists
   - `thumbnail`: (optional string) The basename of the preview thumbnail image
     in the blob container, if one exists
+- `published` (boolean): Whether or not the scene has been published. This affects
+    whether it will appear in timelines.
 - `home_timeline_sort_key` (integer): if present and non-negative, the scene is
   included in the global home timeline, with its position set by the ordering of
   these values.

--- a/handles.ts
+++ b/handles.ts
@@ -102,8 +102,11 @@ export function initializeHandleEndpoints(state: State) {
         // Now, the actual query
 
         const docs = await state.scenes
-          .find({ "handle_id": { "$eq": handle._id } })
-          .sort({ creation_date: -1 }) // todo: publish date; published vs. unpublished
+          .find({
+            "handle_id": { "$eq": handle._id },
+            published: true,
+          })
+          .sort({ creation_date: -1 }) // todo: publish date
           .skip(page_num * page_size)
           .limit(page_size)
           .toArray();

--- a/scenes.ts
+++ b/scenes.ts
@@ -260,7 +260,7 @@ export function initializeSceneEndpoints(state: State) {
     content: SceneContent,
     outgoing_url: t.union([t.string, t.undefined]),
     text: t.string,
-    publish: t.boolean,
+    published: t.union([t.boolean, t.undefined])
   });
 
   type SceneCreationT = t.TypeOf<typeof SceneCreation>;
@@ -332,7 +332,7 @@ export function initializeSceneEndpoints(state: State) {
         content: input.content,
         text: input.text,
         previews: {},
-        published: input.publish,
+        published: input.published ?? true,
       };
 
       if (input.outgoing_url) {

--- a/scenes.ts
+++ b/scenes.ts
@@ -607,7 +607,7 @@ export function initializeSceneEndpoints(state: State) {
     outgoing_url: t.string,
     place: ScenePlace,
     content: SceneContentPatch,
-    publish: t.boolean,
+    published: t.boolean,
   });
 
   type ScenePatchT = t.TypeOf<typeof ScenePatch>;
@@ -721,9 +721,9 @@ export function initializeSceneEndpoints(state: State) {
           }
         }
 
-        if (input.publish !== undefined) {
+        if (input.published !== undefined) {
           allowed = allowed && canEdit;
-          (operation as any)["$set"]["published"] = input.publish;
+          (operation as any)["$set"]["published"] = input.published;
         }
 
         // How did we do?

--- a/scenes.ts
+++ b/scenes.ts
@@ -44,6 +44,7 @@ export interface MongoScene {
   outgoing_url?: string;
   text: string;
 
+  published: boolean;
   home_timeline_sort_key?: number;
 }
 
@@ -199,6 +200,7 @@ export async function sceneToJson(scene: WithId<MongoScene>, state: State, sessi
     text: scene.text,
     liked: session?.likes?.some(x => x.scene_id == scene._id.toString()) ?? false,
     content: {},
+    published: scene.published
   };
 
   if (scene.outgoing_url) {
@@ -258,6 +260,7 @@ export function initializeSceneEndpoints(state: State) {
     content: SceneContent,
     outgoing_url: t.union([t.string, t.undefined]),
     text: t.string,
+    publish: t.boolean,
   });
 
   type SceneCreationT = t.TypeOf<typeof SceneCreation>;
@@ -329,6 +332,7 @@ export function initializeSceneEndpoints(state: State) {
         content: input.content,
         text: input.text,
         previews: {},
+        published: input.publish,
       };
 
       if (input.outgoing_url) {
@@ -603,6 +607,7 @@ export function initializeSceneEndpoints(state: State) {
     outgoing_url: t.string,
     place: ScenePlace,
     content: SceneContentPatch,
+    publish: t.boolean,
   });
 
   type ScenePatchT = t.TypeOf<typeof ScenePatch>;
@@ -716,6 +721,11 @@ export function initializeSceneEndpoints(state: State) {
           }
         }
 
+        if (input.publish !== undefined) {
+          allowed = allowed && canEdit;
+          (operation as any)["$set"]["published"] = input.publish;
+        }
+
         // How did we do?
 
         if (!allowed) {
@@ -765,7 +775,10 @@ export function initializeSceneEndpoints(state: State) {
           res.json({ error: true, message: `invalid page number` });
         }
 
-        const docs = await state.scenes.find({ home_timeline_sort_key: { $gte: 0 } })
+        const docs = await state.scenes.find({
+          home_timeline_sort_key: { $gte: 0 },
+          published: true,
+        })
           .sort({ home_timeline_sort_key: 1 })
           .skip(page_num * page_size)
           .limit(page_size)
@@ -857,7 +870,8 @@ export function initializeSceneEndpoints(state: State) {
             "likes": 1,
             "clicks": 1,
             "shares": 1,
-            "text": 1
+            "text": 1,
+            "published": 1
           })
           .toArray();
 

--- a/superuser.ts
+++ b/superuser.ts
@@ -197,7 +197,7 @@ export function initializeSuperuserEndpoints(state: State) {
       const initialScene = initialSceneID ?
         await state.scenes.findOne({ "_id": initialSceneID }) : null;
 
-      const scenes = await state.scenes.find().toArray();
+      const scenes = await state.scenes.find({ published: true }).toArray();
       const orderedFeed = constructFeed({ scenes, initialScene });
       const operations: AnyBulkWriteOperation<MongoScene>[] = [];
 

--- a/tessellation.ts
+++ b/tessellation.ts
@@ -1,5 +1,5 @@
 import { ObjectId, WithId } from "mongodb";
-import { MongoScene, sceneToJson } from "./scenes.js";
+import { MongoScene } from "./scenes.js";
 import { distance, D2R, R2D } from "@wwtelescope/astro";
 import { GeoVoronoi, geoVoronoi, PointSpherical } from "d3-geo-voronoi";
 import { Response } from "express";
@@ -83,7 +83,10 @@ export function findCell(tessellation: MongoTessellation, raRad: number, decRad:
   * scale quadratically with the number of scenes.
   */
 export async function createGlobalTessellation(state: State, minDistanceRad = 0.01): Promise<MongoTessellation> {
-  const scenes = state.scenes.find({ home_timeline_sort_key: { $gte: 0 } }).sort({ home_timeline_sort_key: 1 });
+  const scenes = state.scenes.find({
+    home_timeline_sort_key: { $gte: 0 },
+    published: true,
+  }).sort({ home_timeline_sort_key: 1 });
   const tessellationScenes: WithId<MongoScene>[] = [];
 
   for await (const scene of scenes) {


### PR DESCRIPTION
This PR adds a `published` field to our scene representation that indicates whether or not the scene has been published, which for now means "will show up in timelines". The queries for handle timelines and the global timeline have been updated to check that `published: true`.

This implementation is pretty straightforward and doesn't account for any sort of "publish on this date" functionality, but I can tackle that in a follow-up PR. Note that this currently requires explicitly specifying whether a scene should be published or not upon scene creation - my thought is that we can leave that to a client to decide, but we could define a default choice here.