### PR TITLE
Expose basic AstroPix association data

### DIFF
--- a/SCHEMA.md
+++ b/SCHEMA.md
@@ -114,6 +114,9 @@ Each document in the `scenes` collection may have the following fields:
 - `home_timeline_sort_key` (integer): if present and non-negative, the scene is
   included in the global home timeline, with its position set by the ordering of
   these values.
+- `astropix`: information associating this scene with an AstroPix record
+  - `publisher_id`: (string) the publisher ID of the AstroPix record
+  - `image_id`: (string) the image ID of the AstroPix record
 
 An ImageLayer record may have the following fields:
 

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "@types/node": "^18.11.15",
     "@types/node-schedule": "^2.1.6",
     "@types/spdx-expression-parse": "^3.0.2",
-    "keycloak-js": "^24.0.1",
+    "keycloak-js": "^25",
     "typescript": "^4.9.4"
   },
   "license": "MIT",

--- a/permissions.ts
+++ b/permissions.ts
@@ -8,7 +8,7 @@ import { State } from "./globals.js";
 export type KeycloakJwtRequest = JwtRequest<JwtPayload & KeycloakTokenParsed>;
 
 export type ConstellationsRole = 'update-home-timeline' | 'update-global-tessellation' |
-                                 'manage-handles' | 'manage-features';
+  'manage-handles' | 'manage-features' | 'manage-astropix';
 
 export function amISuperuser(req: JwtRequest, state: State): boolean {
   return req.auth !== undefined && req.auth.sub === state.config.superuserAccountId;

--- a/scenes.ts
+++ b/scenes.ts
@@ -20,6 +20,7 @@ import { XMLBuilder } from "xmlbuilder2/lib/interfaces";
 
 import { logClickEvent, logImpressionEvent, logLikeEvent, logShareEvent } from "./events.js";
 import { State } from "./globals.js";
+import { hasRole, type KeycloakJwtRequest } from "./permissions.js";
 import { isAllowed as handleIsAllowed } from "./handles.js";
 import { imageToImageset, imageToDisplayJson } from "./images.js";
 import { nearbySceneIDs } from "./tessellation.js";
@@ -272,14 +273,15 @@ export function initializeSceneEndpoints(state: State) {
     content: SceneContent,
     outgoing_url: t.union([t.string, t.undefined]),
     text: t.string,
-    published: t.union([t.boolean, t.undefined])
+    published: t.union([t.boolean, t.undefined]),
+    astropix: t.union([AstroPixInfo, t.undefined]),
   });
 
   type SceneCreationT = t.TypeOf<typeof SceneCreation>;
 
   state.app.post(
     "/handle/:handle/scene",
-    async (req: JwtRequest, res: Response) => {
+    async (req: KeycloakJwtRequest, res: Response) => {
       const handle_name = req.params.handle;
 
       // Are we authorized?
@@ -309,6 +311,14 @@ export function initializeSceneEndpoints(state: State) {
       }
 
       const input: SceneCreationT = maybe.right;
+
+      if (input.astropix !== undefined) {
+        if (!hasRole(req, "manage-astropix")) {
+          res.statusCode = 403;
+          res.json({ error: true, message: "Modification of astropix data forbidden" });
+          return;
+        }
+      }
 
       if (input.content.image_layers !== undefined) {
         for (var layer of input.content.image_layers) {
@@ -349,6 +359,10 @@ export function initializeSceneEndpoints(state: State) {
 
       if (input.outgoing_url) {
         new_rec.outgoing_url = input.outgoing_url;
+      }
+
+      if (input.astropix !== undefined) {
+        new_rec.astropix = input.astropix;
       }
 
       try {
@@ -620,13 +634,14 @@ export function initializeSceneEndpoints(state: State) {
     place: ScenePlace,
     content: SceneContentPatch,
     published: t.boolean,
+    astropix: AstroPixInfo,
   });
 
   type ScenePatchT = t.TypeOf<typeof ScenePatch>;
 
   state.app.patch(
     "/scene/:id",
-    async (req: JwtRequest, res: Response) => {
+    async (req: KeycloakJwtRequest, res: Response) => {
       try {
         // Validate inputs
 
@@ -652,8 +667,8 @@ export function initializeSceneEndpoints(state: State) {
         // For this operation, we might require different permissions depending
         // on what changes are exactly being requested. Note that patch
         // operations should either fully succeed or fully fail -- no partial
-        // applications. Here we cache the `canEdit` permission since everything
-        // uses it.
+        // applications. Here we cache the `canEdit` permission since nearly
+        // everything uses it.
 
         let allowed = true;
         const canEdit = await isAllowed(state, req, scene, "edit");
@@ -665,7 +680,7 @@ export function initializeSceneEndpoints(state: State) {
         // operations we might use below. We have to hack around the typing
         // below, though, because TypeScript takes some elements here to be
         // read-only.
-        let operation: UpdateFilter<MongoScene> = { "$set": {} };
+        let operation: UpdateFilter<MongoScene> = { "$set": {}, "$unset": {} };
 
         if (input.text) {
           allowed = allowed && canEdit;
@@ -736,6 +751,22 @@ export function initializeSceneEndpoints(state: State) {
         if (input.published !== undefined) {
           allowed = allowed && canEdit;
           (operation as any)["$set"]["published"] = input.published;
+        }
+
+        if (input.astropix !== undefined) {
+          allowed = allowed && hasRole(req, "manage-astropix");
+
+          if (!input.astropix.publisher_id && !input.astropix.image_id) {
+            // Setting both publisher and image to empty indicates deletion of
+            // the association.
+            (operation as any)["$unset"]["astropix"] = true;
+          } else if (input.astropix.publisher_id && input.astropix.image_id) {
+            (operation as any)["$set"]["astropix"] = input.astropix;
+          } else {
+            res.statusCode = 400;
+            res.json({ error: true, message: "Invalid input `astropix`: both publisher and image IDs must be defined" });
+            return;
+          }
         }
 
         // How did we do?

--- a/scenes.ts
+++ b/scenes.ts
@@ -46,6 +46,7 @@ export interface MongoScene {
 
   published: boolean;
   home_timeline_sort_key?: number;
+  astropix?: AstroPixInfoT;
 }
 
 const ScenePlace = t.type({
@@ -80,6 +81,13 @@ const ScenePreviews = t.partial({
 });
 
 type ScenePreviewsT = t.TypeOf<typeof ScenePreviews>;
+
+const AstroPixInfo = t.type({
+  publisher_id: t.string,
+  image_id: t.string,
+});
+
+type AstroPixInfoT = t.TypeOf<typeof AstroPixInfo>;
 
 const sceneShareTypes = ["facebook", "linkedin", "twitter", "email", "copy"] as const;
 export type SceneShareType = typeof sceneShareTypes[number];
@@ -205,6 +213,10 @@ export async function sceneToJson(scene: WithId<MongoScene>, state: State, sessi
 
   if (scene.outgoing_url) {
     output.outgoing_url = scene.outgoing_url;
+  }
+
+  if (scene.astropix) {
+    output.astropix = scene.astropix;
   }
 
   // ~"Hydrate" the content
@@ -918,5 +930,4 @@ export function initializeSceneEndpoints(state: State) {
         results: scenes
       });
     });
-
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -418,7 +418,7 @@ __metadata:
     io-ts: ^2.2
     jsdom: ^22.0.0
     jwks-rsa: ^3.0
-    keycloak-js: ^24.0.1
+    keycloak-js: ^25
     mongodb: ^5.0.1
     node-schedule: ^2.1.1
     spdx-expression-parse: ^3.0.1
@@ -1363,13 +1363,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"keycloak-js@npm:^24.0.1":
-  version: 24.0.1
-  resolution: "keycloak-js@npm:24.0.1"
+"keycloak-js@npm:^25":
+  version: 25.0.0
+  resolution: "keycloak-js@npm:25.0.0"
   dependencies:
     js-sha256: ^0.11.0
     jwt-decode: ^4.0.0
-  checksum: ad38c57a72b2e2e5cc456e77fe1903317f55882e76460105f7207020fb17a2ddcbe6a3e2c1cf09a359dfdc9202c9dc446bffe132155fac3296c1507e67c8a418
+  checksum: bfc774c660117e558b1871c1188ae5c7be34b5c64fbc7699abb2a2b921d1b4ad2a47987edead2ff59a30e86b1803b444dbaf2bcda6aa108f5c039450dd884a97
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Modfiying AstroPix info requires a new `manage-astropix` role, since the associations are global data that only trusted administrators should be able to modify.